### PR TITLE
rewrite as a proper minor mode

### DIFF
--- a/org-eww.el
+++ b/org-eww.el
@@ -1,10 +1,10 @@
-;;; org-eww.el --- automatically use eww to preview current org-file when save
+;;; org-eww.el --- automatically use eww to preview the current org file on save
 
-;; Copyright (C) 2004-2015 DarkSun <lujun9972@gmail.com>
+;; Copyright (C) 2004-2016 DarkSun <lujun9972@gmail.com>
 
 ;; Author: DarkSun <lujun9972@gmail.com>
 ;; Created: 2015-12-27
-;; Version: 0.1
+;; Version: 0.2
 ;; Keywords: convenience, eww, org
 ;; Package-Requires: ((org "8.0") (emacs "24.4"))
 ;; URL: https://github.com/lujun9972/org-eww
@@ -31,60 +31,62 @@
 
 ;;; Commentary:
 
-;; org-eww is a little tool that use eww to preview current org-file when save automatically 
+;; org-eww is a little tool that uses eww to automatically preview an
+;; org-file on save.
 
 ;; Quick start:
 
 ;; Put this file under your load-path.
 ;; Insert the following line in your `.emacs':
 ;; (add-hook 'org-mode-hook 'org-eww-mode)
+;; Enable the org-eww-mode in your org buffer.
 
 ;;; Code:
 (require 'org)
 (require 'eww)
 
-(defun org-eww/convert (output-file-name)
-  "Export current org-mode buffer to OUTPUT-FILE-NAME, and call `eww-open-file' to preview it"
+(defun org-eww/preview ()
+  "Export current org-mode buffer to a temp file and call `eww-open-file' to preview it."
   (let ((cb (current-buffer)))
     (save-excursion
       (with-selected-window (display-buffer (get-buffer-create "*eww*"))
         (let ((eww-point (point))
               (eww-window-start (window-start)))
           (with-current-buffer cb
-            (org-export-to-file 'html output-file-name nil nil nil nil nil #'eww-open-file))
+            (org-export-to-file 'html org-eww/htmlfilename nil nil nil nil nil #'eww-open-file))
           (goto-char eww-point)
           (set-window-start nil eww-window-start))))))
 
-;;;###autoload
-(defun org-eww ()
-  "Export current org-mode buffer to a temp file and call `eww-open-file' to preview it"
-  (interactive)
-  (org-eww/convert (make-temp-file (file-name-base buffer-file-name) nil ".html")))
-
-;;;###autoload
-(defun org-eww/turn-on-preview-at-save ()
-  "turn on automatically preview current org-file when save"
-  (interactive)
+(defun org-eww/turn-on-preview-on-save ()
+  "Turn on automatic preview of the current org file on save."
   (progn
-    (add-hook 'after-save-hook #'org-eww nil t)
-    (message "Preview is on.")))
+    (add-hook 'after-save-hook #'org-eww/preview nil t)
+    ;; temp filename into a buffer local variable
+    (setq-local org-eww/htmlfilename (concat buffer-file-name (make-temp-name "-") ".html"))
+    ;; bogus file change to be able to save
+    (insert " ")
+    (delete-backward-char 1)
+    ;; trigger creation of preview buffer
+    (save-buffer)
+    (message "Eww preview is on")))
 
-;;;###autoload
-(defun org-eww/turn-off-preview-at-save ()
-  "turn off automatically preview current org-file when save"
-  (interactive)
+(defun org-eww/turn-off-preview-on-save ()
+  "Turn off automatic preview of the current org file on save."
   (progn
-    (remove-hook 'after-save-hook #'org-eww t)
-    (message "Preview is off.")))
+    (remove-hook 'after-save-hook #'org-eww/preview t)
+    (if (get-buffer "*eww*")
+        (kill-buffer "*eww*"))
+    (if (boundp 'org-eww/htmlfilename) (delete-file org-eww/htmlfilename))
+    (message "Eww preview is off")))
 
 ;;;###autoload
 (define-minor-mode org-eww-mode
   "Preview current org file in eww whenever you save it."
-  :lighter " preview"
-  :keymap (let ((map (make-sparse-keymap)))
-	    (define-key map (kbd "C-c M-p") 'org-eww/turn-on-preview-at-save)
-	    (define-key map (kbd "C-c M-P") 'org-eww/turn-off-preview-at-save)
-	    map))
+  :init-value nil
+  :lighter " eww-prev"
+  (if org-eww-mode
+      (org-eww/turn-off-preview-on-save)
+    (org-eww/turn-on-preview-on-save)))
 
 (provide 'org-eww)
 


### PR DESCRIPTION
I started out cleaning the code a bit and ended making quite big changes. I think it is cleaner this way:

- Enabling and disabling the org-eww minor mode activates and
  deactivates the preview. No need to autoload or make any other
  functions interactive.
- The HTML file is saved in the same directory as the org file.
  Relative links are preserved, so images are displayed in eww.
- The HTML filename is buffer local. Multiple org files can have a
  org-eww preview active simultaneously without extra code.
- The HTML filename is unique and is regenerated only once and not at
  every save.
- The HTML file is deleted when the org-eww-mode is disabled.
- The preview is shown immediately at the org-eww mode activation.
  This is done in a hackish way. I change and reverse the change to
  modify the file so that it could be saved. I could not find a way to
  force saving of an unmodified file.
- Updated doc strings and some function names.

At the same time, I'd like to propose a name change to the package:   org-preview-html

- Descriptive and generic name
- Would get rid of the name conflict with already existing org-eww.el in org-plus-contrib.
- There should be no need to include eww into the name. There could be more than one backend.
- This would pave a way to other similarly named packages with different output formats.
